### PR TITLE
Avoid setImmediate( undefined )

### DIFF
--- a/achieve.js
+++ b/achieve.js
@@ -102,7 +102,10 @@ function listAux(taskNameList,i,username,done)
 			setImmediate(function(){listAux(taskNameList,i+1,username,done);});
 		};
 	})(taskNameList,i,username,done))});
-	else setImmediate(done());
+	else { 
+		var carefulDone=done(); 
+		if (carefulDone != undefined) setImmediate (carefulDone);
+	}
 }
 
 function achieveList(taskNameList,username,done)


### PR DESCRIPTION
v0.12.6 on Windows 7 crashes on setImmeidate(x) where x is undefined. 
Therefore, check for undefined before calling setImmediate()